### PR TITLE
Fix Preserve TPL with unused vars

### DIFF
--- a/src/Expander.php
+++ b/src/Expander.php
@@ -256,7 +256,12 @@ class Expander
 
         if (isset($options["preserveTpl"]) && $options["preserveTpl"] && count($unusedVars) > 0) {
             $result .= "{";
-            $result .= self::$behavior[$op]['sep'];
+            if ($isFirst) {
+                $result .= self::$behavior[$op]['first'];
+                $isFirst = false;
+            } else {
+                $result .= self::$behavior[$op]['sep'];
+            }
             $result .= implode(',', $unusedVars);
             $result .= "}";
         }

--- a/tests/ExpanderTest.php
+++ b/tests/ExpanderTest.php
@@ -138,7 +138,9 @@ class ExpanderTest extends PHPUnit_Framework_TestCase
         return [
             ['{/var,undef}', $this->vars, '/value{/undef}'],
             ['{?var,undef,who}', $this->vars, '?var=value&who=fred{&undef}'],
+            ['/pages/{var}{?undef}', $this->vars, '/pages/value{?undef}'],
             ['{/var,x,undef}/here', $this->vars, '/value/1024{/undef}/here'],
+            ['X{.x,y,undef}', $this->vars, 'X.1024.768{.undef}'],
             ['X{.x,y,undef}', $this->vars, 'X.1024.768{.undef}'],
         ];
     }


### PR DESCRIPTION
Whoever created the preserve template feature failed to include the ability to properly process the template if there are unused vars in the query string. I added a check to see if this was the first time that the separator was being used so that way it can process properly.

On an unrelated note, I share a cubicle with the guy who added the preserve template feature.