### PR TITLE
Add default empty array parameter to UriTemplate::expand

### DIFF
--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -52,7 +52,7 @@ class UriTemplate
      * @throws Exception
      * @return string
      */
-    public function expand(array $variables)
+    public function expand(array $variables = [])
     {
         $result = call_user_func($this->expander, $this->tpl, $variables);
 

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -49,4 +49,16 @@ class UriTemplateTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame('/foo/bar', $actual);
     }
+
+    /**
+     * @covers QL\UriTemplate\UriTemplate
+     */
+    public function testGoodExpansionOnNoParameterUriTemplate()
+    {
+        $expander = new Expander;
+        $tpl = new UriTemplate('/foo/bar', $expander);
+        $actual = $tpl->expand();
+
+        $this->assertSame('/foo/bar', $actual);
+    }
 }


### PR DESCRIPTION
We'd find this light feature change useful in projects where a significant number of calls are made to URIs without parameters.

Unit test included.